### PR TITLE
Fix Elixir 1.17 compilation warnings

### DIFF
--- a/lib/mix/tasks/iana.specials.ex
+++ b/lib/mix/tasks/iana.specials.ex
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Iana.Specials do
   @iana_ip4_spar "#{@iana_url}/iana-ipv4-special-registry/iana-ipv4-special-registry.xml"
   @iana_ip6_spar "#{@iana_url}/iana-ipv6-special-registry/iana-ipv6-special-registry.xml"
 
-  @user_agent {'User-agent', 'Elixir Pfx'}
+  @user_agent {~c"User-agent", ~c"Elixir Pfx"}
   # always point to Pfx's priv directory
   @priv_specials "specials"
 
@@ -66,7 +66,7 @@ defmodule Mix.Tasks.Iana.Specials do
   @spec fetch(String.t()) :: {:error, String.t()} | {Date.t(), [{Pfx.t(), map}]}
   defp fetch(url) do
     # filter out ?xml-model since xmerl chokes on it.
-    with {:ok, {{_http_ver, 200, 'OK'}, _headers, body}} <-
+    with {:ok, {{_http_ver, 200, ~c"OK"}, _headers, body}} <-
            :httpc.request(:get, {url, [@user_agent]}, [], []),
          body <- List.to_string(body),
          body <- Regex.replace(~r/<\?xml-model.*\n/, body, ""),
@@ -157,7 +157,7 @@ defmodule Mix.Tasks.Iana.Specials do
     rfcs =
       for xref <- data do
         case xref do
-          {:xref, [type: 'rfc', data: rfc], _} -> to_string(rfc)
+          {:xref, [type: ~c"rfc", data: rfc], _} -> to_string(rfc)
           _ -> ""
         end
       end


### PR DESCRIPTION
Hello there, the changes fix the following compilation warnings:

```elixir
==> pfx
Compiling 2 files (.ex)
    warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 31 │   @user_agent {'User-agent', 'Elixir Pfx'}
    │                ~
    │
    └─ lib/mix/tasks/iana.specials.ex:31:16

    warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 31 │   @user_agent {'User-agent', 'Elixir Pfx'}
    │                              ~
    │
    └─ lib/mix/tasks/iana.specials.ex:31:30

    warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 69 │     with {:ok, {{_http_ver, 200, 'OK'}, _headers, body}} <-
    │                                  ~
    │
    └─ lib/mix/tasks/iana.specials.ex:69:34

     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
     │
 160 │           {:xref, [type: 'rfc', data: rfc], _} -> to_string(rfc)
     │                          ~
     │
     └─ lib/mix/tasks/iana.specials.ex:160:26
```

Please let me know if I missed something 🙇 